### PR TITLE
chore(package): move builds to Docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 
 # Ignore all test and documentation with "export-ignore".
 /tests            export-ignore
+/travis           export-ignore
 /.codeclimate.yml export-ignore
 /.editorconfig    export-ignore
 /.gitattributes   export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,41 @@
-language: php
+branches:
+  only:
+    - master
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+language: bash
 
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
-
-## Cache composer
 cache:
   directories:
     - $HOME/.composer/cache
 
-before_script:
-  - mkdir -p build/logs
-  - travis_retry composer self-update
-  - travis_retry composer update --no-interaction --prefer-dist
+services:
+  - docker
+
+sudo: required
 
 env:
-  global:
-    - CODECLIMATE_REPO_TOKEN=7396381ced84304988d8d21526e4b626ac3ab455415d4f0a1154da9609d8cdbb
+  matrix:
+    - ENGINE=php VERSION=5.5 INTL=0
+    - ENGINE=php VERSION=5.5 INTL=1
+    - ENGINE=php VERSION=5.6 INTL=0
+    - ENGINE=php VERSION=5.6 INTL=1
+    - ENGINE=php VERSION=7.0 INTL=0
+    - ENGINE=php VERSION=7.0 INTL=1
+    - ENGINE=php VERSION=7.1 INTL=0
+    - ENGINE=php VERSION=7.1 INTL=1
+    - ENGINE=hhvm INTL=0
+
+before_script:
+  - bash travis/helper.sh install
+  - bash travis/helper.sh info
+  - bash travis/helper.sh run mkdir -p build/logs
+  - bash travis/helper.sh run mkdir -p build/cov
+  - bash travis/helper.sh run composer self-update
+  - bash travis/helper.sh run composer update --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/phpcs --standard=psr2 src/
-  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
-  - vendor/bin/phpunit -v --coverage-clover ./build/logs/clover.xml
+  - bash travis/helper.sh phpunit
+  - if [[ $ENGINE == 'php' && $VERSION == '7.0' ]]; then bash travis/helper.sh lint; fi
 
-after_script:
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover; fi
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then php vendor/bin/test-reporter --coverage-report ./build/logs/clover.xml; fi
+after_success:
+  - if [[ $ENGINE == 'php' && $VERSION == '7.0' ]]; then bash travis/helper.sh coverage; fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Software License][ico-license]](LICENSE.md)
 [![Build Status][ico-travis]][link-travis]
 [![Coverage Status][ico-coverage]][link-coverage]
-[![Quality Score][ico-code-quality]][link-code-quality]
 [![Total Downloads][ico-downloads]][link-downloads]
 [![PHP 7 ready][ico-php7ready]][link-travis]
 
@@ -148,12 +147,10 @@ This library is released under the Apache 2.0 license. Please see [License File]
 [ico-license]: https://img.shields.io/badge/license-Apache2-brightgreen.svg?style=flat-square
 [ico-travis]: https://img.shields.io/travis/layershifter/TLDExtract/master.svg?style=flat-square
 [ico-coverage]: https://codeclimate.com/github/layershifter/TLDExtract/badges/coverage.svg
-[ico-code-quality]: https://img.shields.io/scrutinizer/g/layershifter/TLDExtract.svg?style=flat-square
 [ico-downloads]: https://img.shields.io/packagist/dt/layershifter/tld-extract.svg?style=flat-square
 [ico-php7ready]: http://php7ready.timesplinter.ch/layershifter/TLDExtract/master/badge.svg
 
 [link-packagist]: https://packagist.org/packages/layershifter/tld-extract
 [link-travis]: https://travis-ci.org/layershifter/TLDExtract
 [link-coverage]: https://codeclimate.com/github/layershifter/TLDExtract/coverage
-[link-code-quality]: https://scrutinizer-ci.com/g/layershifter/TLDExtract
 [link-downloads]: https://packagist.org/packages/layershifter/tld-extract

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,15 @@
     }
   ],
   "require": {
-    "php": ">=5.5",
+    "php": "^5.5.0 || ^7.0",
     "ext-intl": "*",
     "layershifter/tld-database": "^1.0",
     "layershifter/tld-support": "^1.1"
   },
   "require-dev": {
-    "codeclimate/php-test-reporter": "dev-master",
     "phpmd/phpmd": "@stable",
-    "phpunit/phpunit": "4.8.*",
-    "scrutinizer/ocular": "~1.1",
-    "squizlabs/php_codesniffer": "2.*"
+    "phpunit/phpunit": "^4.8 || ^5.0",
+    "squizlabs/php_codesniffer": "~2.0"
   },
   "autoload": {
     "files": [

--- a/travis/docker/hhvm/Dockerfile
+++ b/travis/docker/hhvm/Dockerfile
@@ -1,0 +1,4 @@
+FROM hhvm/hhvm
+
+RUN apt-get update && apt-get install -y git curl
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-5.5-intl/Dockerfile
+++ b/travis/docker/php-5.5-intl/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:5.5
+
+RUN apt-get update && apt-get install -y git zlib1g-dev libicu-dev g++
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-5.5/Dockerfile
+++ b/travis/docker/php-5.5/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:5.5
+
+RUN apt-get update && apt-get install -y git zlib1g-dev
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-5.6-intl/Dockerfile
+++ b/travis/docker/php-5.6-intl/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:5.6
+
+RUN apt-get update && apt-get install -y git zlib1g-dev libicu-dev g++
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-5.6/Dockerfile
+++ b/travis/docker/php-5.6/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:5.6
+
+RUN apt-get update && apt-get install -y git zlib1g-dev
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-7.0-intl/Dockerfile
+++ b/travis/docker/php-7.0-intl/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:7.0
+
+RUN apt-get update && apt-get install -y git zlib1g-dev libicu-dev g++
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install zip
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-7.0/Dockerfile
+++ b/travis/docker/php-7.0/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:7.0
+
+RUN apt-get update && apt-get install -y git zlib1g-dev
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-7.1-intl/Dockerfile
+++ b/travis/docker/php-7.1-intl/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:7.1
+
+RUN apt-get update && apt-get install -y git zlib1g-dev libicu-dev g++
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-7.1/Dockerfile
+++ b/travis/docker/php-7.1/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:7.1
+
+RUN apt-get update && apt-get install -y git zlib1g-dev
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/helper.sh
+++ b/travis/helper.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Sets IMAGE_NAME if its defined.
+function setImageName() {
+    if [ -f ".docker-image" ]; then
+        IMAGE_NAME="$(cat .docker-image)"
+    else
+        IMAGE_NAME=""
+    fi
+
+    export IMAGE_NAME
+}
+
+# Prepares Docker environment for running utils.
+function prepareEnvironment {
+    if [ "$ENGINE" == "hhvm" ]; then
+        IMAGE_NAME="tld-extract/hhvm"
+        IMAGE_PATH="travis/docker/hhvm"
+    else
+        IMAGE_NAME="tld-extract/php-$VERSION"
+        IMAGE_PATH="travis/docker/php-$VERSION"
+    fi
+
+    if [[ $INTL == "1" ]]; then
+        IMAGE_NAME="tld-extract/php-$VERSION-intl"
+        IMAGE_PATH="travis/docker/php-$VERSION-intl"
+    fi
+
+    docker build -t "$IMAGE_NAME" "$IMAGE_PATH"
+    echo -ne $IMAGE_NAME > .docker-image
+}
+
+# Checks that script is running in Travis CI.
+function testCI {
+   # if [ ! -n "${TRAVIS}" ]; then
+   #     echo "This script must be running in Travis CI."
+   #     exit 1
+   # fi
+   echo 1
+}
+
+# Checks for Docker service.
+function testDocker {
+    docker ps > /dev/null 2>&1
+
+    if [[ "$?" != "0" ]]; then
+        echo "This script requires Docker service for running, check .travis.yml."
+        exit 1
+    fi
+}
+
+setImageName
+
+case "$1" in
+     'coverage')
+        docker run -v "$TRAVIS_BUILD_DIR:/opt/src" \
+            -w "/opt/src" \
+            "$IMAGE_NAME" \
+            curl -s https://codecov.io/bash -o codecov
+
+        docker run -v "$TRAVIS_BUILD_DIR:/opt/src" \
+            -w "/opt/src" \
+            "$IMAGE_NAME" \
+            bash codecov -t "$CODECOV_REPO_TOKEN"
+        ;;
+
+    'info')
+        echo "PHP version  :" `docker run "$IMAGE_NAME" php -r "echo phpversion();"`
+        echo "ext-intl     :" `docker run "$IMAGE_NAME" php -r "echo extension_loaded('intl') ? 'yes' : 'no';"`
+        ;;
+
+    'install')
+        testCI
+        testDocker
+
+        prepareEnvironment
+        ;;
+
+    'lint')
+        docker run -v "$TRAVIS_BUILD_DIR:/opt/src" \
+            -w "/opt/src" \
+            "$IMAGE_NAME" \
+            vendor/bin/phpcs --standard=psr2 src/
+        ;;
+
+    'phpunit')
+        docker run -v "$TRAVIS_BUILD_DIR:/opt/src" \
+            -w "/opt/src" \
+            "$IMAGE_NAME" \
+            vendor/bin/phpunit -v --coverage-clover ./build/logs/clover.xml
+        ;;
+
+    'run')
+        docker run -v "$TRAVIS_BUILD_DIR:/opt/src" \
+            -w "/opt/src" \
+            "$IMAGE_NAME" \
+            "${@:2}"
+        ;;
+esac


### PR DESCRIPTION
This PR introduces test builds with Docker.
Travis default images has built-in `intl` extension while #8 needs to have tests without it.
Also:
* removes unused quality tools;
* adds PHP 7.1 to build matrix;
* updates dependency requirements.