### PR TITLE
Extract: fix typo in class constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ```php
 $result = tld_extract('http://forums.news.cnn.com/');
 var_dump($result);
-    
+
 object(LayerShifter\TLDExtract\Result)#34 (3) {
   ["subdomain":"LayerShifter\TLDExtract\Result":private]=>
   string(11) "forums.news"
@@ -108,7 +108,7 @@ new LayerShifter\TLDExtract\Extract(null, CustomResult::class);
 ## Parsing modes
 
 Package has three modes of parsing:
-* allow ICCAN suffixes (domains are those delegated by ICANN or part of the IANA root zone database);
+* allow ICANN suffixes (domains are those delegated by ICANN or part of the IANA root zone database);
 * allow private domains (domains are amendments submitted to Public Suffix List by the domain holder, as an expression of how they operate their domain security policy);
 * allow custom (domains that are not in list, but can be usable, for example: example, mycompany, etc).
 
@@ -116,10 +116,10 @@ For keeping compatibility with Public Suffix List ideas package runs in all thes
 ```php
 use LayerShifter\TLDExtract\Extract;
 
-new Extract(null, null, Extract::MODE_ALLOW_ICCAN);
+new Extract(null, null, Extract::MODE_ALLOW_ICANN);
 new Extract(null, null, Extract::MODE_ALLOW_PRIVATE);
 new Extract(null, null, Extract::MODE_ALLOW_NOT_EXISTING_SUFFIXES);
-new Extract(null, null, Extract::MODE_ALLOW_ICCAN | Extract::MODE_ALLOW_PRIVATE);
+new Extract(null, null, Extract::MODE_ALLOW_ICANN | Extract::MODE_ALLOW_PRIVATE);
 ```
 
 ## Change log

--- a/src/Extract.php
+++ b/src/Extract.php
@@ -25,9 +25,16 @@ class Extract
 {
 
     /**
-     * @const int If this option provided, extract will consider ICCAN suffixes.
+     * @const int If this option provided, extract will consider ICANN suffixes.
      */
-    const MODE_ALLOW_ICCAN = 2;
+    const MODE_ALLOW_ICANN = 2;
+
+    /**
+     * @const int If this option provided, extract will consider ICANN suffixes.
+     * @deprecated This constant is a typo, please use self::MODE_ALLOW_ICANN
+     */
+    const MODE_ALLOW_ICCAN = self::MODE_ALLOW_ICANN;
+
     /**
      * @const int If this option provided, extract will consider private suffixes.
      */
@@ -102,7 +109,7 @@ class Extract
     public function setExtractionMode($extractionMode = null)
     {
         if (null === $extractionMode) {
-            $this->extractionMode = static::MODE_ALLOW_ICCAN
+            $this->extractionMode = static::MODE_ALLOW_ICANN
                 | static::MODE_ALLOW_PRIVATE
                 | static::MODE_ALLOW_NOT_EXISTING_SUFFIXES;
 
@@ -114,12 +121,12 @@ class Extract
         }
 
         if (!in_array($extractionMode, [
-            static::MODE_ALLOW_ICCAN,
+            static::MODE_ALLOW_ICANN,
             static::MODE_ALLOW_PRIVATE,
             static::MODE_ALLOW_NOT_EXISTING_SUFFIXES,
-            static::MODE_ALLOW_ICCAN | static::MODE_ALLOW_PRIVATE,
-            static::MODE_ALLOW_ICCAN | static::MODE_ALLOW_NOT_EXISTING_SUFFIXES,
-            static::MODE_ALLOW_ICCAN | static::MODE_ALLOW_PRIVATE | static::MODE_ALLOW_NOT_EXISTING_SUFFIXES,
+            static::MODE_ALLOW_ICANN | static::MODE_ALLOW_PRIVATE,
+            static::MODE_ALLOW_ICANN | static::MODE_ALLOW_NOT_EXISTING_SUFFIXES,
+            static::MODE_ALLOW_ICANN | static::MODE_ALLOW_PRIVATE | static::MODE_ALLOW_NOT_EXISTING_SUFFIXES,
             static::MODE_ALLOW_PRIVATE | static::MODE_ALLOW_NOT_EXISTING_SUFFIXES
         ], true)
         ) {
@@ -326,7 +333,7 @@ class Extract
 
         $type = $this->suffixStore->getType($entry);
 
-        if ($this->extractionMode & static::MODE_ALLOW_ICCAN && $type === Store::TYPE_ICCAN) {
+        if ($this->extractionMode & static::MODE_ALLOW_ICANN && $type === Store::TYPE_ICANN) {
             return true;
         }
 

--- a/src/Extract.php
+++ b/src/Extract.php
@@ -30,7 +30,6 @@ class Extract
     const MODE_ALLOW_ICANN = 2;
 
     /**
-     * @const int If this option provided, extract will consider ICANN suffixes.
      * @deprecated This constant is a typo, please use self::MODE_ALLOW_ICANN
      */
     const MODE_ALLOW_ICCAN = self::MODE_ALLOW_ICANN;

--- a/tests/ExtractTest.php
+++ b/tests/ExtractTest.php
@@ -45,7 +45,7 @@ class ExtractTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructor()
     {
-        $defaultMode = Extract::MODE_ALLOW_ICCAN
+        $defaultMode = Extract::MODE_ALLOW_ICANN
             | Extract::MODE_ALLOW_PRIVATE
             | Extract::MODE_ALLOW_NOT_EXISTING_SUFFIXES;
 
@@ -75,10 +75,10 @@ class ExtractTest extends \PHPUnit_Framework_TestCase
 
         // Variant 4.
 
-        $extract = new Extract(null, null, Extract::MODE_ALLOW_ICCAN);
+        $extract = new Extract(null, null, Extract::MODE_ALLOW_ICANN);
 
         static::assertAttributeInstanceOf(Store::class, 'suffixStore', $extract);
-        static::assertAttributeEquals(Extract::MODE_ALLOW_ICCAN, 'extractionMode', $extract);
+        static::assertAttributeEquals(Extract::MODE_ALLOW_ICANN, 'extractionMode', $extract);
         static::assertAttributeEquals(Result::class, 'resultClassName', $extract);
     }
 
@@ -117,15 +117,15 @@ class ExtractTest extends \PHPUnit_Framework_TestCase
 
         $extract->setExtractionMode(null);
         static::assertAttributeEquals(
-            Extract::MODE_ALLOW_ICCAN | Extract::MODE_ALLOW_PRIVATE | Extract::MODE_ALLOW_NOT_EXISTING_SUFFIXES,
+            Extract::MODE_ALLOW_ICANN | Extract::MODE_ALLOW_PRIVATE | Extract::MODE_ALLOW_NOT_EXISTING_SUFFIXES,
             'extractionMode',
             $extract
         );
 
         // Variant 2.
 
-        $extract->setExtractionMode(Extract::MODE_ALLOW_ICCAN);
-        static::assertAttributeEquals(Extract::MODE_ALLOW_ICCAN, 'extractionMode', $extract);
+        $extract->setExtractionMode(Extract::MODE_ALLOW_ICANN);
+        static::assertAttributeEquals(Extract::MODE_ALLOW_ICANN, 'extractionMode', $extract);
 
         // Variant 3.
 
@@ -400,13 +400,13 @@ class ExtractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test for parse() withExtract::MODE_ALLOW_ICCAN | Extract::MODE_ALLOW_PRIVATE options.
+     * Test for parse() withExtract::MODE_ALLOW_ICANN | Extract::MODE_ALLOW_PRIVATE options.
      *
      * @return void
      */
     public function testParseOnlyExisting()
     {
-        $extract = new Extract(null, null, Extract::MODE_ALLOW_ICCAN | Extract::MODE_ALLOW_PRIVATE);
+        $extract = new Extract(null, null, Extract::MODE_ALLOW_ICANN | Extract::MODE_ALLOW_PRIVATE);
 
         static::assertNull($extract->parse('example.example')->getSuffix());
         static::assertNull($extract->parse('a.example.example')->getSuffix());
@@ -420,13 +420,13 @@ class ExtractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test for parse() with Extract::MODE_ALLOW_ICCAN | Extract::MODE_ALLOW_PRIVATE options.
+     * Test for parse() with Extract::MODE_ALLOW_ICANN | Extract::MODE_ALLOW_PRIVATE options.
      *
      * @return void
      */
     public function testParseDisablePrivate()
     {
-        $extract = new Extract(null, null, Extract::MODE_ALLOW_ICCAN | Extract::MODE_ALLOW_NOT_EXISTING_SUFFIXES);
+        $extract = new Extract(null, null, Extract::MODE_ALLOW_ICANN | Extract::MODE_ALLOW_NOT_EXISTING_SUFFIXES);
 
         static::assertEquals('example', $extract->parse('example.example')->getSuffix());
         static::assertEquals('example', $extract->parse('a.example.example')->getSuffix());
@@ -444,13 +444,13 @@ class ExtractTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test for parse() with MODE_ALLOW_ICCAN option.
+     * Test for parse() with MODE_ALLOW_ICANN option.
      *
      * @return void
      */
-    public function testParseICCANOption()
+    public function testParseICANNOption()
     {
-        $extract = new Extract(null, null, Extract::MODE_ALLOW_ICCAN);
+        $extract = new Extract(null, null, Extract::MODE_ALLOW_ICANN);
 
         static::assertNull($extract->parse('example.example')->getSuffix());
         static::assertNull($extract->parse('a.example.example')->getSuffix());

--- a/tests/StaticTest.php
+++ b/tests/StaticTest.php
@@ -30,7 +30,7 @@ class StaticTest extends \PHPUnit_Framework_TestCase
         static::assertEquals('www.domain.com', $result->getFullHost());
         static::assertEquals('domain.com', $result->getRegistrableDomain());
 
-        $result = tld_extract('a.b.blogspot.com', Extract::MODE_ALLOW_ICCAN);
+        $result = tld_extract('a.b.blogspot.com', Extract::MODE_ALLOW_ICANN);
 
         static::assertEquals('a.b.blogspot.com', $result->getFullHost());
         static::assertEquals('blogspot.com', $result->getRegistrableDomain());


### PR DESCRIPTION
The constant `Extract::MODE_ALLOW_ICCAN` is a typo, the correct version should be `Extract::MODE_ALLOW_ICANN`

As this is a breaking change. I chose to deprecate the existing spelling of it and simply add (and use) the corrected version.