### PR TITLE
fix(IDN): use INTL_IDNA_VARIANT_UTS46 for idn_* functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
     - ENGINE=php VERSION=7.0 INTL=1
     - ENGINE=php VERSION=7.1 INTL=0
     - ENGINE=php VERSION=7.1 INTL=1
+    - ENGINE=php VERSION=7.2 INTL=0
+    - ENGINE=php VERSION=7.2 INTL=1
     - ENGINE=hhvm INTL=0
 
 before_script:

--- a/src/IDN.php
+++ b/src/IDN.php
@@ -38,6 +38,10 @@ class IDN
             return $this->transformer->encode($domain);
         }
 
+        if (defined('INTL_IDNA_VARIANT_UTS46')) {
+            return idn_to_ascii($domain, 0, INTL_IDNA_VARIANT_UTS46);
+        }
+
         return idn_to_ascii($domain);
     }
 
@@ -52,6 +56,10 @@ class IDN
     {
         if ($this->transformer) {
             return $this->transformer->decode($domain);
+        }
+
+        if (defined('INTL_IDNA_VARIANT_UTS46')) {
+            return idn_to_utf8($domain, 0, INTL_IDNA_VARIANT_UTS46);
         }
 
         return idn_to_utf8($domain);

--- a/travis/docker/php-7.2-intl/Dockerfile
+++ b/travis/docker/php-7.2-intl/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:7.2-rc
+
+RUN apt-get update && apt-get install -y git zlib1g-dev libicu-dev g++
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer

--- a/travis/docker/php-7.2/Dockerfile
+++ b/travis/docker/php-7.2/Dockerfile
@@ -1,0 +1,6 @@
+FROM php:7.2-rc
+
+RUN apt-get update && apt-get install -y git zlib1g-dev
+RUN docker-php-ext-install zip
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer


### PR DESCRIPTION
This PR:
- adds PHP 7.2 to test matrix
- as `INTL_IDNA_VARIANT_2003` is deprecated in PHP 7.2,  we use INTL_IDNA_VARIANT_UTS46 for idn_* functions if it's defined