### PR TITLE
Underscore at end of hostname label causes parsing to fail #31

### DIFF
--- a/src/Extract.php
+++ b/src/Extract.php
@@ -55,7 +55,7 @@ class Extract
      * @see   https://tools.ietf.org/html/rfc1034
      * @see   https://tools.ietf.org/html/rfc2181
      */
-    const HOSTNAME_PATTERN = '#^((?!-)[a-z0-9_-]{0,62}[a-z0-9]\.)+[a-z]{2,63}|[xn\-\-a-z0-9]]{6,63}$#';
+    const HOSTNAME_PATTERN = '#^((?!-)[a-z0-9_-]{0,62}[a-z0-9_]\.)+[a-z]{2,63}|[xn\-\-a-z0-9]]{6,63}$#';
 
     /**
      * @var int Value of extraction options.

--- a/tests/ExtractTest.php
+++ b/tests/ExtractTest.php
@@ -527,9 +527,19 @@ class ExtractTest extends \PHPUnit_Framework_TestCase
         static::assertEquals('com', $this->extract->parse('dkim._domainkey.example.com')->getSuffix());
         static::assertEquals('example', $this->extract->parse('dkim._domainkey.example.com')->getHostname());
         static::assertEquals('dkim._domainkey', $this->extract->parse('dkim._domainkey.example.com')->getSubdomain());
+        static::assertEquals(array('dkim','_domainkey'), $this->extract->parse('dkim._domainkey.example.com')->getSubdomains());
 
         static::assertEquals('com', $this->extract->parse('_spf.example.com')->getSuffix());
         static::assertEquals('example', $this->extract->parse('_spf.example.com')->getHostname());
         static::assertEquals('_spf', $this->extract->parse('_spf.example.com')->getSubdomain());
+
+        static::assertEquals('com', $this->extract->parse('foo_.example.com')->getSuffix());
+        static::assertEquals('example', $this->extract->parse('foo_.example.com')->getHostname());
+        static::assertEquals('foo_', $this->extract->parse('foo_.example.com')->getSubdomain());
+
+        static::assertEquals('com', $this->extract->parse('bar.foo_.example.com')->getSuffix());
+        static::assertEquals('example', $this->extract->parse('bar.foo_.example.com')->getHostname());
+        static::assertEquals('bar.foo_', $this->extract->parse('bar.foo_.example.com')->getSubdomain());
+        static::assertEquals(array('bar', 'foo_'), $this->extract->parse('bar.foo_.example.com')->getSubdomains());
     }
 }


### PR DESCRIPTION
- Allow underscores at end of subdomain labels.
- Amended tests for the above.