### PR TITLE
fix(Extract): make Extract::suffixExists protected

### DIFF
--- a/src/Extract.php
+++ b/src/Extract.php
@@ -359,7 +359,7 @@ class Extract
      *
      * @return bool
      */
-    private function suffixExists($entry)
+    protected function suffixExists($entry)
     {
         if (!$this->suffixStore->isExists($entry)) {
             return false;


### PR DESCRIPTION
Changed method from private to protected.

Related issue #34 